### PR TITLE
fix(readme): restore star history chart with working mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,11 +585,11 @@ See the [User Guide](GUIDE.md) for detailed usage instructions, examples, and ti
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=OctagonAI%2Fkalshi-trading-bot-cli&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#OctagonAI/kalshi-trading-bot-cli&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=OctagonAI/kalshi-trading-bot-cli&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=OctagonAI/kalshi-trading-bot-cli&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=OctagonAI/kalshi-trading-bot-cli&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=OctagonAI/kalshi-trading-bot-cli&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=OctagonAI/kalshi-trading-bot-cli&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=OctagonAI/kalshi-trading-bot-cli&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
The Star History chart in the README is currently broken because the upstream service is unable to fetch stargazer data under current GitHub API restrictions, so the image fails to render.

This change repoints the chart to the star-history.dera.page mirror, which serves the same chart from an alternative data source that requires no API token. The chart image now uses the /svg endpoint and the wrapping link uses the mirror's hash-based URL scheme, keeping the same repo, type, and legend values.

This fixes the broken chart with no other behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Star History embeds to use the new `star-history.dera.page` URLs.
  * Replaced outdated Star History endpoints in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->